### PR TITLE
Experimental Core Text rasterizer

### DIFF
--- a/visual/LayerBitmapImpl.cpp
+++ b/visual/LayerBitmapImpl.cpp
@@ -48,6 +48,10 @@
 #include "VirtualKey.h"
 #endif
 
+#if defined(__APPLE__)
+#include "darwin/CoreTextFontRasterizer.h"
+#endif
+
 //---------------------------------------------------------------------------
 // prototypes
 //---------------------------------------------------------------------------
@@ -68,11 +72,18 @@ enum {
 #ifdef _WIN32
 	FONT_RASTER_GDI,
 #endif
+#ifdef KRKRZ_CORETEXT_SUPPORT
+	FONT_RASTER_CORETEXT,
+#endif
 	FONT_RASTER_EOT
 };
 static FontRasterizer* TVPFontRasterizers[FONT_RASTER_EOT];
 static bool TVPFontRasterizersInit = false;
+#if defined(KRKRZ_CORETEXT_SUPPORT)
+static tjs_int TVPCurrentFontRasterizers = FONT_RASTER_CORETEXT;
+#else
 static tjs_int TVPCurrentFontRasterizers = FONT_RASTER_FREE_TYPE;
+#endif
 
 void TVPInializeFontRasterizers() {
 	if( TVPFontRasterizersInit == false ) {
@@ -80,7 +91,9 @@ void TVPInializeFontRasterizers() {
 #ifdef _WIN32
 		TVPFontRasterizers[FONT_RASTER_GDI] = new GDIFontRasterizer();
 #endif
-
+#ifdef KRKRZ_CORETEXT_SUPPORT
+		TVPFontRasterizers[FONT_RASTER_CORETEXT] = new CoreTextFontRasterizer();
+#endif
 		TVPFontSystem = new FontSystem();
 		TVPFontRasterizersInit = true;
 	}

--- a/visual/LayerBitmapImpl.cpp
+++ b/visual/LayerBitmapImpl.cpp
@@ -79,11 +79,7 @@ enum {
 };
 static FontRasterizer* TVPFontRasterizers[FONT_RASTER_EOT];
 static bool TVPFontRasterizersInit = false;
-#if defined(KRKRZ_CORETEXT_SUPPORT)
-static tjs_int TVPCurrentFontRasterizers = FONT_RASTER_CORETEXT;
-#else
 static tjs_int TVPCurrentFontRasterizers = FONT_RASTER_FREE_TYPE;
-#endif
 
 void TVPInializeFontRasterizers() {
 	if( TVPFontRasterizersInit == false ) {

--- a/visual/darwin/CoreTextFontFallback.mm
+++ b/visual/darwin/CoreTextFontFallback.mm
@@ -1,0 +1,17 @@
+/**
+ * @file      CoreTextFontFallback.mm
+ * @author    Hikaru Terazono (3c1u) <3c1u@vulpesgames.tokyo>
+ * @brief     Core Text-based font rasterizer.
+ * @date      2020-08-14
+ *
+ * @copyright Copyright (c) 2020 Hikaru Terazono. All rights reserved.
+ *
+ */
+
+#import <Cocoa/Cocoa.h>
+#import <CoreFoundation/CoreFoundation.h>
+
+CFArrayRef CoreTextFont_GetCurrentSystemLanguages() {
+  return (__bridge CFArrayRef)
+      [[NSUserDefaults standardUserDefaults] arrayForKey:@"AppleLanguages"];
+}

--- a/visual/darwin/CoreTextFontRasterizer.cc
+++ b/visual/darwin/CoreTextFontRasterizer.cc
@@ -1,0 +1,150 @@
+/**
+ * @file      CoreTextFontRasterizer.cc
+ * @author    Hikaru Terazono (3c1u) <3c1u@vulpesgames.tokyo>
+ * @brief     Core Text-based font rasterizer.
+ * @date      2020-08-14
+ *
+ * @copyright Copyright (c) 2020 Hikaru Terazono. All rights reserved.
+ *
+ */
+
+/* FIXME: FUCK SURROGATE PAIRS! WE DON'T TREAT EM! */
+
+#include "CoreTextFontRasterizer.h"
+#include "CoreTextFontStorage.h"
+
+#include <vector>
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <CoreText/CoreText.h>
+
+#include "DebugIntf.h"
+#include "FontSystem.h"
+#include "LayerBitmapIntf.h"
+#include "MsgIntf.h"
+#include "StringUtil.h"
+
+// ---------------------------------------------
+extern FontSystem *TVPFontSystem;
+// ---------------------------------------------
+
+CoreTextFontRasterizer::CoreTextFontRasterizer()
+    : m_refCount(1), m_lastBitmap(nullptr), m_fontFace(nullptr) {}
+
+CoreTextFontRasterizer::~CoreTextFontRasterizer() {}
+
+void CoreTextFontRasterizer::AddRef() { ++m_refCount; }
+
+void CoreTextFontRasterizer::Release() {
+  // invalidate the bitmap cache
+  m_lastBitmap = nullptr;
+
+  if (--m_refCount == 0) {
+    delete this;
+  }
+}
+
+void CoreTextFontRasterizer::ApplyFont(class tTVPNativeBaseBitmap *bmp,
+                                       bool                        force) {
+  // surpress redraw?
+  if (m_lastBitmap == bmp || !force)
+    return;
+
+  ApplyFont(bmp->GetFont());
+  m_lastBitmap = bmp;
+}
+
+void CoreTextFontRasterizer::ApplyFont(const struct tTVPFont &font) {
+  // TODO: vertical text is not supported yet
+
+  std::vector<tjs_string> faces;
+  tjs_string              face = font.Face.AsStdString();
+
+  if (face[0] == TJS_W(',')) {
+    tjs_string stdname = TVPFontSystem->GetBeingFont(face);
+    faces.push_back(stdname);
+  } else {
+    split(face, tjs_string(TJS_W(",")), faces);
+    for (auto i = faces.begin(); i != faces.end();) {
+      tjs_string &x = *i;
+      x             = Trim(x);
+      if (TVPFontSystem->FontExists(x) == false) {
+        i = faces.erase(i);
+      } else {
+        i++;
+      }
+    }
+    if (faces.empty()) {
+      faces.push_back(tjs_string(TVPFontSystem->GetDefaultFontName()));
+    }
+  }
+
+  // sanitize options
+  tjs_uint32 opt = 0;
+  opt |= (font.Flags & TVP_TF_ITALIC) ? TVP_TF_ITALIC : 0;
+  opt |= (font.Flags & TVP_TF_BOLD) ? TVP_TF_BOLD : 0;
+  opt |= (font.Flags & TVP_TF_UNDERLINE) ? TVP_TF_UNDERLINE : 0;
+  opt |= (font.Flags & TVP_TF_STRIKEOUT) ? TVP_TF_STRIKEOUT : 0;
+  opt |= (font.Flags & TVP_TF_FONTFILE) ? TVP_TF_FONTFILE : 0;
+
+  // create CTFontCollection from faces
+
+  auto storage = CoreTextFontStorage::getInstance();
+
+  if (m_fontFace && (m_fontFace->getFaceName() != faces[0])) {
+    // invalidate font face
+    delete m_fontFace;
+    m_fontFace = nullptr;
+  }
+
+  if (!m_fontFace && !(m_fontFace = storage->createFontFace(faces, opt))) {
+    TVPThrowExceptionMessage(TJS_W("failed to create a font face: %1"),
+                             faces[0]);
+  }
+
+  // ensure font options
+  m_fontFace->ensureOptions(opt);
+
+  // why?
+  m_lastBitmap = nullptr;
+}
+
+void CoreTextFontRasterizer::GetTextExtent(tjs_char ch, tjs_int &w,
+                                           tjs_int &h) {
+  // TODO:
+  w = 0;
+  h = 0;
+}
+
+tjs_int CoreTextFontRasterizer::GetAscentHeight() {
+  // TODO:
+  return 0;
+}
+
+tTVPCharacterData *
+CoreTextFontRasterizer::GetBitmap(const tTVPFontAndCharacterData &font,
+                                  tjs_int aofsx, tjs_int aofsy) {
+  // TODO:
+
+  // the actual rasterization goes here
+
+  return nullptr;
+}
+
+void CoreTextFontRasterizer::GetGlyphDrawRect(const ttstr &    text,
+                                              struct tTVPRect &area) {
+  // TODO:
+}
+
+bool CoreTextFontRasterizer::AddFont(const ttstr &            storage,
+                                     std::vector<tjs_string> *faces) {
+  auto instance = CoreTextFontStorage::getInstance();
+  return instance->loadFont(storage, faces);
+}
+
+void CoreTextFontRasterizer::GetFontList(std::vector<ttstr> &   list,
+                                         tjs_uint32             flags,
+                                         const struct tTVPFont &font) {
+  auto instance = CoreTextFontStorage::getInstance();
+  return instance->populateFontList(list, flags, font);
+}

--- a/visual/darwin/CoreTextFontRasterizer.cc
+++ b/visual/darwin/CoreTextFontRasterizer.cc
@@ -149,8 +149,8 @@ void CoreTextFontRasterizer::GetTextExtent(tjs_char ch, tjs_int &w,
   }
 }
 
-bool CoreTextFontRasterizer::TryGetTextExtentWithFontFace(tjs_char ch, tjs_int &w,
-                                           tjs_int &h, CoreTextFontFace *fontFace) {
+bool CoreTextFontRasterizer::TryGetTextExtentWithFontFace(
+    tjs_char ch, tjs_int &w, tjs_int &h, CoreTextFontFace *fontFace) {
   auto    fontRef   = fontFace->getFont();
   UniChar character = static_cast<UniChar>(ch);
   CGGlyph glyph     = 0;

--- a/visual/darwin/CoreTextFontRasterizer.h
+++ b/visual/darwin/CoreTextFontRasterizer.h
@@ -40,6 +40,5 @@ private:
 };
 
 #define KRKRZ_CORETEXT_SUPPORT
-#define KRKRZ_DISABLE_FREE_TYPE
 
 #endif // __APPLE__

--- a/visual/darwin/CoreTextFontRasterizer.h
+++ b/visual/darwin/CoreTextFontRasterizer.h
@@ -13,6 +13,9 @@
 
 #include "tjsCommHead.h"
 
+#include <CoreText/CoreText.h>
+#include <vector>
+
 #include "CharacterData.h"
 #include "FontRasterizer.h"
 
@@ -37,6 +40,14 @@ private:
   size_t                      m_refCount;
   class tTVPNativeBaseBitmap *m_lastBitmap;
   class CoreTextFontFace *    m_fontFace;
+
+  std::vector<class CoreTextFontFace *> m_fallbackFonts;
+
+  tTVPCharacterData *TryGetBitmap(const tTVPFontAndCharacterData &font,
+                                  tjs_int aofsx, tjs_int aofsy,
+                                  CTFontRef fontRef);
+  
+  class CoreTextFontFace * getFontFace() const;
 };
 
 #define KRKRZ_CORETEXT_SUPPORT

--- a/visual/darwin/CoreTextFontRasterizer.h
+++ b/visual/darwin/CoreTextFontRasterizer.h
@@ -1,0 +1,45 @@
+/**
+ * @file      CoreTextFontRasterizer.h
+ * @author    Hikaru Terazono (3c1u) <3c1u@vulpesgames.tokyo>
+ * @brief     Core Text-based font rasterizer.
+ * @date      2020-08-14
+ *
+ * @copyright Copyright (c) 2020 Hikaru Terazono. All rights reserved.
+ *
+ */
+
+#if defined(__APPLE__)
+#pragma once
+
+#include "tjsCommHead.h"
+
+#include "CharacterData.h"
+#include "FontRasterizer.h"
+
+class CoreTextFontRasterizer : public FontRasterizer {
+public:
+  CoreTextFontRasterizer();
+  virtual ~CoreTextFontRasterizer();
+  void    AddRef() override;
+  void    Release() override;
+  void    ApplyFont(class tTVPNativeBaseBitmap *bmp, bool force) override;
+  void    ApplyFont(const struct tTVPFont &font) override;
+  void    GetTextExtent(tjs_char ch, tjs_int &w, tjs_int &h) override;
+  tjs_int GetAscentHeight() override;
+  tTVPCharacterData *GetBitmap(const tTVPFontAndCharacterData &font,
+                               tjs_int aofsx, tjs_int aofsy) override;
+  void GetGlyphDrawRect(const ttstr &text, struct tTVPRect &area) override;
+  bool AddFont(const ttstr &storage, std::vector<tjs_string> *faces) override;
+  void GetFontList(std::vector<ttstr> &list, tjs_uint32 flags,
+                   const struct tTVPFont &font) override;
+
+private:
+  size_t                      m_refCount;
+  class tTVPNativeBaseBitmap *m_lastBitmap;
+  class CoreTextFontFace *    m_fontFace;
+};
+
+#define KRKRZ_CORETEXT_SUPPORT
+#define KRKRZ_DISABLE_FREE_TYPE
+
+#endif // __APPLE__

--- a/visual/darwin/CoreTextFontRasterizer.h
+++ b/visual/darwin/CoreTextFontRasterizer.h
@@ -46,8 +46,14 @@ private:
   tTVPCharacterData *TryGetBitmap(const tTVPFontAndCharacterData &font,
                                   tjs_int aofsx, tjs_int aofsy,
                                   CTFontRef fontRef);
-  
-  class CoreTextFontFace * getFontFace() const;
+
+  class CoreTextFontFace *getFontFace() const;
+
+  bool GetGlyphDrawRectWithFontFace(const ttstr &text, struct tTVPRect &area,
+                                    CoreTextFontFace *face);
+
+  bool TryGetTextExtentWithFontFace(tjs_char ch, tjs_int &w, tjs_int &h,
+                                    CoreTextFontFace *fontFace);
 };
 
 #define KRKRZ_CORETEXT_SUPPORT

--- a/visual/darwin/CoreTextFontStorage.cc
+++ b/visual/darwin/CoreTextFontStorage.cc
@@ -1,0 +1,303 @@
+/**
+ * @file      CoreTextFontStorage.cc
+ * @author    Hikaru Terazono (3c1u) <3c1u@vulpesgames.tokyo>
+ * @brief     The storage for cached `CTFontDescriptor`s.
+ * @date      2020-08-14
+ *
+ * @copyright Copyright (c) 2020 Hikaru Terazono. All rights reserved.
+ *
+ */
+
+#include "CoreTextFontStorage.h"
+
+#include "BinaryStream.h"
+#include "DebugIntf.h"
+#include "LayerBitmapIntf.h"
+#include "MsgIntf.h"
+
+CoreTextFontFace::CoreTextFontFace(CTFontDescriptorRef descriptor,
+                                   tjs_string const &  faceName,
+                                   tjs_uint32          options)
+    : m_descriptor(descriptor), m_faceName(faceName), m_options(options) {}
+
+CoreTextFontFace::~CoreTextFontFace() { CFRelease(m_descriptor); }
+
+tjs_string const &CoreTextFontFace::getFaceName() const { return m_faceName; }
+
+void CoreTextFontFace::ensureOptions(tjs_uint32 options) {
+  if (m_options == options)
+    return;
+}
+
+// ----------------------------------------------------------------------
+
+CoreTextFontStorage *CoreTextFontStorage::getInstance() {
+  static CoreTextFontStorage instance{};
+  return &instance;
+}
+
+CoreTextFontStorage::CoreTextFontStorage() {
+  m_fontMap = CFDictionaryCreateMutable(CFAllocatorGetDefault(), 0,
+                                        &kCFTypeDictionaryKeyCallBacks,
+                                        &kCFTypeDictionaryValueCallBacks);
+  if (!m_fontMap) {
+    TVPThrowExceptionMessage(TJS_W("failed to create a font cache"));
+  }
+}
+
+CoreTextFontStorage::~CoreTextFontStorage() { CFRelease(m_fontMap); }
+
+bool CoreTextFontStorage::loadFont(const ttstr &            path,
+                                   std::vector<tjs_string> *faces) {
+  TVPAddLog(TVPFormatMessage(TJS_W("loading font: '%1'"), path));
+
+  // convert path to CFStringRef
+  auto path_ = CFStringCreateWithBytes(
+      CFAllocatorGetDefault(), reinterpret_cast<const uint8_t *>(path.c_str()),
+      path.GetLen() << 1, kCFStringEncodingUTF16LE, false);
+
+  if (!path_) {
+    TVPThrowExceptionMessage(TJS_W("font name conversion failed: '%1'"), path);
+  }
+
+  auto fontDescriptors =
+      reinterpret_cast<CFArrayRef>(CFDictionaryGetValue(m_fontMap, path_));
+
+  if (fontDescriptors) {
+    TVPAddLog(TVPFormatMessage(TJS_W("font already cached: '%1'"), path));
+
+    populateFontFaces(faces, fontDescriptors);
+    CFRelease(path_);
+
+    return false;
+  }
+
+  // load font
+  auto fontData = getFontData(path);
+  if (!fontData) {
+    TVPThrowExceptionMessage(TVPCannotOpenFontFile, path);
+  }
+
+  TVPAddLog(TVPFormatMessage(TJS_W("font loaded into the memory: '%1'"), path));
+
+  fontDescriptors = CTFontManagerCreateFontDescriptorsFromData(fontData);
+  CFRelease(fontData);
+
+  if (!fontDescriptors) {
+    TVPThrowExceptionMessage(TVPCannotOpenFontFile, path);
+  }
+
+  // insert into m_fontMap
+  CFDictionaryAddValue(m_fontMap, path_, fontDescriptors);
+  TVPAddLog(TVPFormatMessage(TJS_W("font successfully cahed: '%1'"), path));
+
+  populateFontFaces(faces, fontDescriptors);
+  CFRelease(path_);
+
+  return true;
+}
+
+void CoreTextFontStorage::populateFontList(std::vector<ttstr> &   list,
+                                           tjs_uint32             flags,
+                                           const struct tTVPFont &_font) {
+  // unused parameter _font (why?)
+  auto        count = CFDictionaryGetCount(m_fontMap);
+  const void *values[count];
+
+  CFDictionaryGetKeysAndValues(m_fontMap, nullptr, values);
+
+  for (CFIndex j = 0; j < count; j++) {
+    CFArrayRef descriptors = reinterpret_cast<CFArrayRef>(values[j]);
+    auto       len         = CFArrayGetCount(descriptors);
+
+    for (CFIndex i = 0; i < len; i++) {
+      auto d = reinterpret_cast<CTFontDescriptorRef>(
+          CFArrayGetValueAtIndex(descriptors, i));
+      if (!d) {
+        continue;
+      }
+
+      if (!testFont(d, flags))
+        continue;
+
+      auto familyName = reinterpret_cast<CFStringRef>(
+          CTFontDescriptorCopyAttribute(d, kCTFontDisplayNameAttribute));
+
+      if (!familyName) {
+        // family name not present
+        TVPAddLog(TJS_W("family name not present"));
+        continue;
+      }
+
+      auto bufSize = CFStringGetLength(familyName) << 2;
+      auto cStr    = new char[bufSize];
+
+      // clear the buffer
+      memset(cStr, 0, bufSize);
+
+      if (!CFStringGetCString(familyName, cStr, bufSize,
+                              kCFStringEncodingUTF16LE)) {
+        TVPThrowExceptionMessage(TJS_W("font family name conversion failed"));
+      }
+
+      auto faceName = tjs_string(reinterpret_cast<tjs_char const *>(cStr));
+
+      delete[] cStr;
+
+      TVPAddLog(
+          TVPFormatMessage(TJS_W("populating family name: '%1'"), faceName));
+
+      list.push_back(std::move(faceName));
+
+      CFRelease(familyName);
+    }
+  }
+}
+
+CFDataRef CoreTextFontStorage::getFontData(const ttstr &path) {
+  auto in = TVPCreateBinaryStreamForRead(path, TJS_W(""));
+
+  if (!in) {
+    return nullptr;
+  }
+
+  // FIXME: this loads the entire font into the memory; not ideal
+  auto size    = in->GetSize();
+  auto dataBuf = new uint8_t[size];
+  in->ReadBuffer(dataBuf, size);
+
+  auto data = CFDataCreate(CFAllocatorGetDefault(), dataBuf, size);
+
+  delete[] dataBuf;
+  delete in;
+
+  return data;
+}
+
+void CoreTextFontStorage::populateFontFaces(std::vector<tjs_string> *faces,
+                                            CFArrayRef descriptors) {
+  TVPAddLog(TJS_W("populating faces..."));
+
+  auto len = CFArrayGetCount(descriptors);
+
+  for (CFIndex i = 0; i < len; i++) {
+    auto d = reinterpret_cast<CTFontDescriptorRef>(
+        CFArrayGetValueAtIndex(descriptors, i));
+    if (!d) {
+      continue;
+    }
+
+    auto familyName = reinterpret_cast<CFStringRef>(
+        CTFontDescriptorCopyAttribute(d, kCTFontDisplayNameAttribute));
+
+    if (!familyName) {
+      // family name not present
+      TVPAddLog(TJS_W("family name not present"));
+      continue;
+    }
+
+    auto bufSize = CFStringGetLength(familyName) << 2;
+    auto cStr    = new char[bufSize];
+
+    // clear the buffer
+    memset(cStr, 0, bufSize);
+
+    if (!CFStringGetCString(familyName, cStr, bufSize,
+                            kCFStringEncodingUTF16LE)) {
+      TVPThrowExceptionMessage(TJS_W("font family name conversion failed"));
+    }
+
+    auto faceName = tjs_string(reinterpret_cast<tjs_char const *>(cStr));
+
+    delete[] cStr;
+
+    TVPAddLog(
+        TVPFormatMessage(TJS_W("populating family name: '%1'"), faceName));
+
+    faces->push_back(std::move(faceName));
+
+    CFRelease(familyName);
+  }
+}
+
+bool CoreTextFontStorage::testFont(CTFontDescriptorRef descriptor,
+                                   tjs_uint32          flags) {
+  // TODO: implement font test
+  return true;
+}
+
+CoreTextFontFace *
+CoreTextFontStorage::createFontFace(std::vector<tjs_string> const &faces,
+                                    tjs_uint32                     flags) {
+  // unused parameter _font (why?)
+  auto        count = CFDictionaryGetCount(m_fontMap);
+  const void *values[count];
+
+  CFDictionaryGetKeysAndValues(m_fontMap, nullptr, values);
+
+  for (auto const &face : faces) {
+    // convert face into CFString
+    auto faceStr = CFStringCreateWithBytesNoCopy(
+        CFAllocatorGetDefault(),
+        reinterpret_cast<uint8_t const *>(face.c_str()), face.size() << 1,
+        kCFStringEncodingUTF16LE, false, kCFAllocatorNull);
+    if (!faceStr) {
+      TVPThrowExceptionMessage(
+          TJS_W("failed to convert the face string into CFString: %1"), face);
+    }
+
+    for (CFIndex j = 0; j < count; j++) {
+      CFArrayRef descriptors = reinterpret_cast<CFArrayRef>(values[j]);
+      auto       len         = CFArrayGetCount(descriptors);
+
+      for (CFIndex k = 0; k < len; k++) {
+        auto d = reinterpret_cast<CTFontDescriptorRef>(
+            CFArrayGetValueAtIndex(descriptors, k));
+        if (!d) {
+          continue;
+        }
+
+        auto displayName = reinterpret_cast<CFStringRef>(
+            CTFontDescriptorCopyAttribute(d, kCTFontDisplayNameAttribute));
+        if (!displayName) {
+          continue;
+        }
+
+        if (CFStringCompare(displayName, faceStr, 0) == kCFCompareEqualTo) {
+          CFRelease(displayName);
+          CFRelease(faceStr);
+          CFRetain(d);
+
+          return new CoreTextFontFace(d, face, flags);
+        }
+
+        // try localized names
+        CFStringRef lang = nullptr;
+        displayName      = reinterpret_cast<CFStringRef>(
+            CTFontDescriptorCopyLocalizedAttribute(
+                d, kCTFontDisplayNameAttribute, &lang));
+        if (!displayName) {
+          continue;
+        }
+
+        if (lang) {
+          CFRelease(lang);
+        }
+
+        if (CFStringCompare(displayName, faceStr, 0) == kCFCompareEqualTo) {
+          CFRelease(displayName);
+          CFRelease(faceStr);
+          CFRetain(d);
+
+          return new CoreTextFontFace(d, face, flags);
+        }
+
+        CFRelease(displayName);
+      }
+    }
+
+    CFRelease(faceStr);
+  }
+
+  return nullptr;
+}

--- a/visual/darwin/CoreTextFontStorage.cc
+++ b/visual/darwin/CoreTextFontStorage.cc
@@ -15,6 +15,8 @@
 #include "LayerBitmapIntf.h"
 #include "MsgIntf.h"
 
+// ----------------------------------------------------------------------
+
 CoreTextFontFace::CoreTextFontFace(CTFontDescriptorRef descriptor,
                                    tjs_string const &  faceName,
                                    tjs_uint32          options)

--- a/visual/darwin/CoreTextFontStorage.cc
+++ b/visual/darwin/CoreTextFontStorage.cc
@@ -62,9 +62,9 @@ bool CoreTextFontFace::getGlyphRectFromCharcode(struct tTVPRect &rt,
   CGSize advance;
   CGRect rect;
 
-  CTFontGetBoundingRectsForGlyphs(m_font, kCTFontOrientationHorizontal, &glyph,
+  CTFontGetBoundingRectsForGlyphs(m_font, kCTFontOrientationDefault, &glyph,
                                   &rect, 1);
-  CTFontGetAdvancesForGlyphs(m_font, kCTFontOrientationHorizontal, &glyph,
+  CTFontGetAdvancesForGlyphs(m_font, kCTFontOrientationDefault, &glyph,
                              &advance, 1);
 
   rt.set_size(rect.size.width, rect.size.height);
@@ -232,6 +232,20 @@ void CoreTextFontStorage::populateFontFaces(std::vector<tjs_string> *faces,
         CFArrayGetValueAtIndex(descriptors, i));
     if (!d) {
       continue;
+    }
+
+    // don't use vertical fonts
+    auto orientation = reinterpret_cast<CFNumberRef>(
+        CTFontDescriptorCopyAttribute(d, kCTFontOrientationAttribute));
+
+    if (orientation) {
+      uint32_t orientationVal = 0;
+      CFNumberGetValue(orientation, kCFNumberLongType, &orientationVal);
+      CFRelease(orientation);
+
+      if (orientationVal != kCTFontOrientationHorizontal) {
+        continue;
+      }
     }
 
     auto familyName = reinterpret_cast<CFStringRef>(

--- a/visual/darwin/CoreTextFontStorage.h
+++ b/visual/darwin/CoreTextFontStorage.h
@@ -29,13 +29,15 @@ public:
   tjs_uint32          getOptions() const;
   CTFontDescriptorRef getDescriptor() const;
   CTFontRef           getFont() const;
-  CGFloat           getHeight() const;
+  CGFloat             getHeight() const;
 
   void createFontWithHeight(CGFloat height);
   void ensureOptions(tjs_uint32 options);
 
   bool getGlyphRectFromCharcode(struct tTVPRect &rt, tjs_char code,
                                 tjs_int &advancex, tjs_int &advancey);
+
+  static std::vector<CoreTextFontFace *> defaultFallbackFonts();
 
 private:
   CTFontDescriptorRef m_descriptor;

--- a/visual/darwin/CoreTextFontStorage.h
+++ b/visual/darwin/CoreTextFontStorage.h
@@ -25,12 +25,23 @@ public:
   CoreTextFontFace(CoreTextFontFace const &) = delete;
   CoreTextFontFace &operator=(CoreTextFontFace const &) = delete;
 
-  tjs_string const &getFaceName() const;
-  void              ensureOptions(tjs_uint32 options);
+  tjs_string const &  getFaceName() const;
+  tjs_uint32          getOptions() const;
+  CTFontDescriptorRef getDescriptor() const;
+  CTFontRef           getFont() const;
+  CGFloat           getHeight() const;
+
+  void createFontWithHeight(CGFloat height);
+  void ensureOptions(tjs_uint32 options);
+
+  bool getGlyphRectFromCharcode(struct tTVPRect &rt, tjs_char code,
+                                tjs_int &advancex, tjs_int &advancey);
 
 private:
   CTFontDescriptorRef m_descriptor;
+  CTFontRef           m_font;
   tjs_string          m_faceName;
+  CGFloat             m_height;
   tjs_uint32          m_options;
 };
 

--- a/visual/darwin/CoreTextFontStorage.h
+++ b/visual/darwin/CoreTextFontStorage.h
@@ -1,0 +1,58 @@
+/**
+ * @file      CoreTextFontStorage.h
+ * @author    Hikaru Terazono (3c1u) <3c1u@vulpesgames.tokyo>
+ * @brief     The storage for cached `CTFontDescriptor`s.
+ * @date      2020-08-14
+ *
+ * @copyright Copyright (c) 2020 Hikaru Terazono. All rights reserved.
+ *
+ */
+
+#pragma once
+
+#include "tjsCommHead.h"
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <CoreText/CoreText.h>
+
+class CoreTextFontFace {
+public:
+  CoreTextFontFace(CTFontDescriptorRef descriptor, tjs_string const &faceName,
+                   tjs_uint32 options);
+  ~CoreTextFontFace();
+
+  // no copy
+  CoreTextFontFace(CoreTextFontFace const &) = delete;
+  CoreTextFontFace &operator=(CoreTextFontFace const &) = delete;
+
+  tjs_string const &getFaceName() const;
+  void              ensureOptions(tjs_uint32 options);
+
+private:
+  CTFontDescriptorRef m_descriptor;
+  tjs_string          m_faceName;
+  tjs_uint32          m_options;
+};
+
+class CoreTextFontStorage {
+public:
+  static CoreTextFontStorage *getInstance();
+  CoreTextFontStorage(CoreTextFontStorage const &) = delete;
+  CoreTextFontStorage &operator=(CoreTextFontStorage const &) = delete;
+  bool              loadFont(const ttstr &path, std::vector<tjs_string> *faces);
+  void              populateFontList(std::vector<ttstr> &list, tjs_uint32 flags,
+                                     const struct tTVPFont &_font);
+  CoreTextFontFace *createFontFace(std::vector<tjs_string> const &faces,
+                                   tjs_uint32                     flags);
+
+private:
+  CFDataRef getFontData(const ttstr &path);
+  void      populateFontFaces(std::vector<tjs_string> *faces,
+                              CFArrayRef               descriptors);
+  bool      testFont(CTFontDescriptorRef descriptor, tjs_uint32 flags);
+  CoreTextFontStorage();
+  ~CoreTextFontStorage();
+
+  CFMutableDictionaryRef m_fontMap; // CFMutableDictionaryRef<CFStringRef,
+                                    // CFArrayRef<CTFontDescriptorRef>>
+};


### PR DESCRIPTION
macOS向けにCoreTextのフォントラスタライザーを書いてみました．一応それなりには動くし，システムのフォールバックフォントを持ってこれますが，フォールバック処理がやや甘い気がします．

マルチプラットフォームの理念からは離れてしまっているので，趣旨にあわないようでしたらクローズしても構いません．