### PR TITLE
Disable 'register' keyword on C++17

### DIFF
--- a/sound/xmmlib.h
+++ b/sound/xmmlib.h
@@ -58,6 +58,10 @@
 
 #if	(defined(__SSE__)&&defined(__GNUC__))||defined(_MSC_VER)
 
+#if __cplusplus >= 201703L
+#define register
+#endif
+
 /* We need type definitions from the XMM header file.  */
 #include <xmmintrin.h>
 #ifdef	_MSC_VER


### PR DESCRIPTION
The 'register' keyword is deprecated since C++11, and completely removed in
C++17. This fixes the build on C++17. Also, many of modern compilers seem to
ignore the 'register' keyword.